### PR TITLE
New Feature: copy-merge and line-copy bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Multiple clipboards for Visual Studio Code
 
 ## Description
 
-Override the regular `Copy` and `Cut` commands to keep selections in a clipboard ring
+Override the regular `Copy` and `Cut` commands to keep selections in a clipboard ring. Also adds the
+ability to copy several blocks of text into a single copy buffer.
 
 ## Commands
 
 * Copy (`Cmd+c` on OSX or `Ctrl+c` on Windows and Linux)
+* Merge-Copy (`Cmd+Shift+c` on OSX or `Ctrl+Shift+c` on Windows and Linux)
 * Cut (`Cmd+x` on OSX or `Ctrl+x` on Windows and Linux)
+* Merge-Cut (`Cmd+Shift+x` on OSX or `Ctrl+Shift+x` on Windows and Linux)
 * Select clipboard to paste  (`Cmd+Alt+v` on OSX or `Ctrl+Alt+v` on Windows and Linux)
 * Paste and cycle through clipboard items (`Cmd+Shift+v` on OSX or `Ctrl+Shift+v` on Windows and Linux)
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,14 @@
 			{
 				"command": "multiclip.clearBuffer",
 				"title": "Clear Multiclip Buffer"
+			},
+			{
+				"command": "multiclip.copyMerge",
+				"title" : "Multiclip Copy and Merge to Clipboard"
+			},
+			{
+				"command": "multiclip.cutMerge",
+				"title" : "Multiclip Cut and Merge to Clipboard"
 			}
 		],
 		"keybindings": [
@@ -77,6 +85,18 @@
 				"mac": "shift+cmd+v",
 				"command": "multiclip.paste",
 				"when": "editorTextFocus && editorLangId != 'markdown'"
+			},
+			{
+				"key": "shift+ctrl+c",
+				"mac": "shift+cmd+c",
+				"command": "multiclip.copyMerge",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "shift+ctrl+x",
+				"mac": "shift+cmd+x",
+				"command": "multiclip.cutMerge",
+				"when": "editorTextFocus"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,40 +9,47 @@ export function activate(context: vscode.ExtensionContext) {
 	let bufSize = 10;
 	var copyBuffer = new Array;
 	var pasteIndex = 0;
-	
+
+	function newCopyBuf(e,merge:boolean=false) : string {
+		let d = e.document;
+		let sel = e.selection;
+		let txt: string = d.getText(new Range(sel.start, sel.end));
+		if (merge) {
+			if (copyBuffer.length===0) {
+				copyBuffer.push("");
+			}
+			copyBuffer[0] += txt;
+		} else {
+			if (txt.trim().length > 0 && !copyBuffer.find(value=> value === txt)) {
+				copyBuffer.unshift(txt);
+				if (copyBuffer.length > bufSize){
+					copyBuffer = copyBuffer.slice(0, bufSize);
+				}
+			}
+		}
+		pasteIndex = 0;
+		return txt;
+	}
+
 	var disposables = [];
 	disposables.push( vscode.commands.registerCommand('multiclip.clearBuffer', () => {
 		copyBuffer = new Array;
 		pasteIndex = 0;
 	}));
-	disposables.push( vscode.commands.registerCommand('multiclip.copy', () => {
-		let e = Window.activeTextEditor;
-		let d = e.document;
-		let sel = e.selection;
-		
-		let txt: string = d.getText(new Range(sel.start, sel.end));
-		if (txt.trim().length > 0 && !copyBuffer.find(value=> value === txt)) {
-			copyBuffer.unshift(txt);
-			if (copyBuffer.length > bufSize){
-				copyBuffer = copyBuffer.slice(0, bufSize);
-			}
-		}
-		pasteIndex = 0;
+	disposables.push( vscode.commands.registerCommand('multiclip.copyMerge', () => {
+		newCopyBuf(Window.activeTextEditor,true);
 		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
 	}));
+	disposables.push( vscode.commands.registerCommand('multiclip.copy', () => {
+		newCopyBuf(Window.activeTextEditor);
+		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
+	}));
+	disposables.push( vscode.commands.registerCommand('multiclip.cutMerge', () => {
+		newCopyBuf(Window.activeTextEditor,true);
+		vscode.commands.executeCommand("editor.action.clipboardCutAction");
+	}));
 	disposables.push( vscode.commands.registerCommand('multiclip.cut', () => {
-		let e = Window.activeTextEditor;
-		let d = e.document;
-		let sel = e.selection;
-		
-		let txt: string = d.getText(new Range(sel.start, sel.end));
-		if (txt.trim().length > 0 && !copyBuffer.find(value=> value === txt)) {
-			copyBuffer.unshift(txt);
-			if (copyBuffer.length > bufSize){
-				copyBuffer = copyBuffer.slice(0, bufSize);
-			}
-		}
-		pasteIndex = 0;
+		newCopyBuf(Window.activeTextEditor);
 		vscode.commands.executeCommand("editor.action.clipboardCutAction");
 	}));
 	disposables.push( vscode.commands.registerCommand('multiclip.paste', () => {
@@ -50,15 +57,15 @@ export function activate(context: vscode.ExtensionContext) {
 			Window.setStatusBarMessage("Multiclip: Nothing to paste", 3000);
 			return;
 		}
-	
+
 		let e = Window.activeTextEditor;
 		let d = e.document;
-		
+
 		let txt: string = d.getText(new Range(e.selection.start, e.selection.end));
 		if (txt === copyBuffer[pasteIndex]) {
 			pasteIndex = ++pasteIndex < copyBuffer.length ? pasteIndex : 0;
 		}
-		
+
 		let sel = e.selections;
 		e.edit( function(edit) {
 			e.selections.forEach(sel => {
@@ -67,22 +74,22 @@ export function activate(context: vscode.ExtensionContext) {
 				//TODO: Put selection in clipboard
 			});
 		});
-		
+
 	}));
 	disposables.push( vscode.commands.registerCommand('multiclip.list', () => {
 		if (copyBuffer.length == 0) {
 			Window.setStatusBarMessage("Multiclip: Nothing to paste", 3000);
 			return;
 		}
-		
+
 		var opts: QuickPickOptions = { matchOnDescription: true, placeHolder: "What to paste" };
 		var items: QuickPickItem[] = [];
-		
-		
+
+
 		for (var i=0; i<copyBuffer.length; i++){
 			items.push({ label: (i+1).toString(), description: copyBuffer[i]});
 		};
-		
+
 		Window.showQuickPick(items).then( (item) => {
 			if (!item) {
 				return;
@@ -90,7 +97,7 @@ export function activate(context: vscode.ExtensionContext) {
 			let e = Window.activeTextEditor;
 			let d = e.document;
 			let sel = e.selections;
-			
+
 			e.edit( function(edit) {
 				e.selections.forEach(sel => {
 					let txt = item.description;
@@ -98,11 +105,11 @@ export function activate(context: vscode.ExtensionContext) {
 					//TODO: Put selection in clipboard
 				});
 			});
-			
+
 		})
 
 	}));
-	
+
 	context.subscriptions.concat(disposables);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,10 +10,23 @@ export function activate(context: vscode.ExtensionContext) {
 	var copyBuffer = new Array;
 	var pasteIndex = 0;
 
-	function newCopyBuf(e,merge:boolean=false) : string {
-		let d = e.document;
+	function newCopyBuf(e:vscode.TextEditor,merge:boolean=false) : string {
+		let d:vscode.TextDocument = e.document;
 		let sel = e.selection;
 		let txt: string = d.getText(new Range(sel.start, sel.end));
+
+		// A copy of a zero length line means copy the whole line.
+		if (txt.length === 0) {
+			let eol;
+			try {
+				const files = vscode.workspace.getConfiguration("files");
+				eol = files.get("eol","\n");
+			} catch (e) {
+				eol = "\n";
+			}
+			txt = d.lineAt(sel.start.line).text + eol ;
+		}
+
 		if (merge) {
 			if (copyBuffer.length===0) {
 				copyBuffer.push("");


### PR DESCRIPTION
An editor I used to use had the ability to hit Shift-Ctrl-C to MERGE a line with the current copy buffer. I missed that feature in VS Code.

The basic idea is that you can collect a number of lines from one file or part of a file into a single copy buffer and then paste them all together. I find that I would like to use the feature periodically, but instead need to copy and paste into a temporary file or similar.

I'd already picked up this plug-in, and I realized that adding the ability to merge-copy would be really trivial. It will only work if you use Shift-Ctrl-V to do the paste from the clipboard ring at present, but I've run out of time to hack on it at the moment, and I personally am mapping Ctrl-V to the multiclip paste to get the feature to work by default.

I also remap Shift-Ctrl-X to cut-merge.

Please let me know your thoughts. I'd love to see this feature in the main Multiclip extension.